### PR TITLE
Add 'document' to the resource types to capture

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as https from 'https';
 
 const getRequestHandler = (allowedHosts: string[]) => (interceptedRequest: any) => {
   const url: string = interceptedRequest.url()
-  const supportedResourceType = ['xhr', 'fetch'];
+  const supportedResourceType = ['xhr', 'fetch', 'document'];
   if (!supportedResourceType.includes(interceptedRequest.resourceType()) || !allowedHosts.find(allowedHost => url.includes(allowedHost))) {
     return interceptedRequest.continue();
   }


### PR DESCRIPTION
Needed to capture a 'document' request. Alternatively, this could be configurable like `allowedHosts`. Since there are many other resource types, and someone may need to intercept those.