### PR TITLE
Switch to CommonJS-style module

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,7 +2,8 @@ import * as puppeteer from 'puppeteer';
 import { Page, Browser } from 'puppeteer';
 import * as nock from 'nock';
 import { MOCK_PAGE_PATH, DEFAULT_PP_CONFIG } from './const';
-import useNock from '../';
+
+const useNock = require('../');
 
 // const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const getSelectorText = async (page: any, selector: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,9 @@ const getRequestHandler = (allowedHosts: string[]) => (interceptedRequest: any) 
     });
 };
 
-export default async (page: any, allowedHosts: string[]) => {
+const useNock = async function(page: any, allowedHosts: string[]) {
   await page.setRequestInterception(true);
   page.on('request', getRequestHandler(allowedHosts));
 };
+
+module.exports = useNock;


### PR DESCRIPTION
Updated to 1.0.5 and discovered my old tests crashed because they're expecting to be able to `require` the module. This is also the mode described in the docs.